### PR TITLE
Add Troubleshooting doc + instructions to fix mpv crashing on Vivaldi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # [Krabby]
 
-<img src="https://www.iconfinder.com/icons/877852/download/svg/512" height="168" align="right">
-
 [![Platform](https://img.shields.io/badge/Platform-Linux%20|%20FreeBSD%20|%20OpenBSD%20|%20macOS-lightgray)](#supported-platforms)
 [![Browser](https://img.shields.io/badge/Browser-Chrome%20|%20Firefox%20|%20surf-lightgray)](#browser-compatibility)
 [![IRC](https://img.shields.io/badge/IRC-%23krabby-blue)](https://webchat.freenode.net/#krabby)
 [![Plugins](https://img.shields.io/badge/Plugins-%23krabby%20%23plugin-green)](https://github.com/search?q=topic:krabby+topic:plugin)
 
-###### [Installation](#installation) | [Configuration](docs/configuration.md) | [Documentation](docs) | [Supported platforms](#supported-platforms) | [Browser compatibility](#browser-compatibility) | [Contributing](CONTRIBUTING)
+###### [Installation](#installation) | [Configuration](docs/configuration.md) | [Documentation](docs) | [Supported platforms](#supported-platforms) | [Browser compatibility](#browser-compatibility) | [Troubleshooting](docs/troubleshooting.md) | [Contributing](CONTRIBUTING)
+
+<img src="https://www.iconfinder.com/icons/877852/download/svg/512" height="168" align="right">
 
 Krabby is a browser extension (for [Chrome], [Firefox] and [surf]) for keyboard-based navigation, inspired by [Kakoune].
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,6 +191,10 @@ See [chrome-editor] for a complete reference.
 const { settings } = krabby
 
 settings['mpv-config'] = ['-no-config', '-no-terminal']
+
+settings['mpv-environment'] = {
+  MPV_HOME: '~/.mpv'
+}
 ```
 
 ## HTML filter

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,32 @@
+# Troubleshooting
+
+- [mpv commands don't work on Vivaldi](#mpv-commands-dont-work-on-vivaldi)
+
+## mpv commands don't work on Vivaldi
+
+Vivaldi loads it's own libffmpeg library on start-up. This was an optional video compatibility feature up until Vivaldi 3.0 and had to be enabled manually by executing `/opt/vivaldi/update-ffmpeg`.
+Later versions set this up automatically.  
+More information about it in this [help post](https://help.vivaldi.com/article/html5-proprietary-media-on-linux/) and in the [changelog](https://vivaldi.com/es/changelog-vivaldi-3/).
+
+The loaded `libffmpeg.so` used by Vivaldi might not be compatible with the version of ffmpeg used by mpv, causing it to crash.
+
+It's possible to work around this problem by clearing the `LD_PRELOAD` environment variable that's passed to mpv like so:
+
+1. Add the following to to your configuration located at `~/.config/krabby/config.js`
+   ```javascript
+   const { settings } = krabby
+   
+   // Clear the LD_PRELOAD environment variable. Fixes mpv crash on Vivaldi.
+   settings['mpv-environment'] = {
+     LD_PRELOAD: ''
+   }
+   ```
+2. Run
+   ```sh
+   cd ~/.config/krabby
+   make
+   ```
+3. Reload the extension from vivaldi://extensions/ or restart Vivaldi.
+
+mpv should work fine afterwards.
+

--- a/src/krabby/extension/extension.js
+++ b/src/krabby/extension/extension.js
@@ -118,13 +118,21 @@ function KrabbyExtension(krabby) {
     if (reverse) {
       playlist.reverse()
     }
-    krabby.extensions.shell.send('mpv', ...krabby.settings['mpv-config'], ...playlist)
+    krabby.extensions.shell.port.postMessage({
+      command: 'mpv',
+      arguments: [...krabby.settings['mpv-config'], ...playlist],
+      environment: krabby.settings['mpv-environment']
+    })
   }
 
   krabby.commands.mpvResume = () => {
     const media = krabby.commands.player().media
     media.pause()
-    krabby.extensions.shell.send('mpv', ...krabby.settings['mpv-config'], location.href, '-start', media.currentTime.toString())
+    krabby.extensions.shell.port.postMessage({
+        command: 'mpv',
+        arguments: [...krabby.settings['mpv-config'], location.href, '-start', media.currentTime.toString()],
+        environment: krabby.settings['mpv-environment']
+    })
   }
 
   // Mappings ──────────────────────────────────────────────────────────────────
@@ -197,7 +205,7 @@ function KrabbyExtension(krabby) {
   krabby.modes.modal.map('Image', ['Alt', 'Enter'], () => krabby.commands.download(krabby.selections, (selection) => selection.src), 'Download image', 'Open links')
 
   // mpv
-  krabby.modes.modal.map('Document', ['KeyM'], () => krabby.extensions.shell.send('mpv', ...krabby.settings['mpv-config'], location.href), 'Play with mpv', 'mpv')
+  krabby.modes.modal.map('Document', ['KeyM'], () => krabby.extensions.shell.port.postMessage({ command: 'mpv', arguments: [...krabby.settings['mpv-config'], location.href], environment: krabby.settings['mpv-environment'] }), 'Play with mpv', 'mpv')
 
   return krabby
 }

--- a/src/krabby/web/krabby.js
+++ b/src/krabby/web/krabby.js
@@ -14,6 +14,7 @@ function Krabby({ dormant = true } = {}) {
 
   krabby.settings = {}
   krabby.settings['mpv-config'] = ['-no-terminal']
+  krabby.settings['mpv-environment'] = {}
   krabby.settings['html-filter'] = ['pandoc', '--from', 'html', '--to', 'markdown']
 
   switch (true) {


### PR DESCRIPTION
Closes #19 

I hope the description about the problem isn't too wordy. Feel free to edit out the context of the problem if you think it's unnecessary. Also, the fix depends on `settings['mpv-environment']` being implemented, of course.
I also added an index, to mimic [the example](https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md) you linked me. I don't know if it looks weird with only one entry though.

I also changed the README and moved the inline krabby logo a little bit lower so that the new link to Troubleshooting didn't wrap around and look weird on desktop. I hope it looks fine like this.

This is my first time ever doing a pull request so forgive me if I forgot anything.