### PR TITLE
Add note to website's live demo

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -270,7 +270,7 @@
         See <a href="https://youtube.com/playlist?list=PLdr-HcjEDx_kOnqvLcE5T1tq9rAVwmths">YouTube · Krabby</a> and <a href="https://github.com/alexherbo2/krabby-resources">krabby-resources</a> for all available demos.
       </p>
       <!-- Live demo ---------------------------------------------------------->
-      <h2 id="live-demo"><a href="#live-demo">Live demo</a></h2>
+      <h2 id="live-demo"><a href="#live-demo">Live demo (no installation needed)</a></h2>
       <ul>
         <li>
           Make sure to deactivate your extension and browser bindings.


### PR DESCRIPTION
When I was reading through the Krabby webpage, the thought of installing several dependencies just to try out a browser extension made me nervous. I wished there was a way to try it out without making any system changes. Turns out, there was; I just didn't understand that the `Live Demo` section already had Krabby installed through the webpage. 

This extra bit of context should help newcomers understand that no installation is required and eliminate that mental uncertainty so that they know that they can give it a shot!